### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ vendorUrl=https://enonic.com
 
 xpVersion=8.0.0-B4
 libAdminUiVersion=4.4.0
-version=1.0.4-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump master `version` from `1.0.4-SNAPSHOT` to `2.0.0-SNAPSHOT` for the XP 8 line
- Add `releaseBranch:` CI config listing both `master` and `1.x` so the release tooling recognises both as release branches
- Companion PR on `1.x` adds the same workflow change so pushes to that maintenance branch are also classified as release-branch builds

The `1.x` maintenance branch was created from commit `4d85c47` (post-`v1.0.3` "Updated to next SNAPSHOT version"), so its `gradle.properties` stays at `1.0.4-SNAPSHOT`.

Reference: app-booster's analogous `master` / `1.x` split.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` from master is green
- [ ] After companion `1.x` PR merges, a CI run on `1.x` classifies it as a release branch