### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block (listing both `master` and `1.x`) to the workflow on the `1.x` maintenance branch
- Pushes to `1.x` are only classified as release-branch builds when the action reads the `releaseBranch` value from the branch's own workflow file — hence this companion PR alongside the master-side change
- No version bump or other changes — `gradle.properties` stays at `1.0.4-SNAPSHOT` for the XP 7 maintenance line

Companion PR on master: #481.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a CI run on `1.x` classifies it as a release branch