### PR TITLE
Fix XP 8 admin API removals #483

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 lib-admin-ui = "4.4.0"
-lib-graphql = "2.1.0"
-lib-mustache = "2.1.1"
+lib-graphql = "3.0.0-SNAPSHOT"
+lib-mustache = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-admin-ui = { module = "com.enonic.lib:lib-admin-ui", version.ref = "lib-admin-ui" }

--- a/src/main/resources/admin/tools/main/main.html
+++ b/src/main/resources/admin/tools/main/main.html
@@ -28,8 +28,5 @@
 <!-- App javascript -->
 <script type="text/javascript" src="{{assetsUri}}/js/bundle.js" data-config-service-url="{{configServiceUrl}}"></script>
 
-<!-- Append the launcher -->
-<script type="text/javascript" src="{{launcherPath}}" data-config-theme="dark" async></script>
-
 </body>
 </html>

--- a/src/main/resources/admin/tools/main/main.js
+++ b/src/main/resources/admin/tools/main/main.js
@@ -1,9 +1,8 @@
-const admin = require('/lib/xp/admin');
 const mustache = require('/lib/mustache');
 const portal = require('/lib/xp/portal');
 const i18n = require('/lib/xp/i18n');
 
-function handleGet() {
+function handleGet(req) {
     const view = resolve('./main.html');
 
     const params = {
@@ -11,9 +10,8 @@ function handleGet() {
         appName: i18n.localize({
             key: 'admin.tool.displayName',
             bundles: ['i18n/phrases'],
-            locale: admin.getLocales()
+            locale: req.locales
         }),
-        launcherPath: admin.getLauncherPath(),
         configServiceUrl: portal.serviceUrl({service: 'config'})
     };
 

--- a/src/main/resources/services/config/config.js
+++ b/src/main/resources/services/config/config.js
@@ -4,17 +4,15 @@ var admin = require('/lib/xp/admin');
 var portal = require('/lib/xp/portal');
 
 function handleGet() {
+    var toolUri = admin.getToolUrl(app.name, 'main');
     return {
         status: 200,
         contentType: 'application/json',
         body: {
-            adminUrl: admin.getBaseUri(),
+            adminUrl: toolUri.substring(0, toolUri.indexOf('/' + app.name)),
             appId: app.name,
             assetsUri: portal.assetUrl({path: ''}),
-            toolUri: admin.getToolUrl(
-                app.name,
-                'main'
-            ),
+            toolUri: toolUri,
             services: {
                 visualization: portal.serviceUrl({ service: 'visualization'}),
                 graphQlUrl: portal.serviceUrl({ service: 'graphql'}),

--- a/src/main/resources/services/i18n/i18n.js
+++ b/src/main/resources/services/i18n/i18n.js
@@ -1,17 +1,15 @@
 var i18n = require('/lib/xp/i18n');
-var admin = require('/lib/xp/admin');
 
-exports.get = function () {
+exports.get = function (req) {
 
     return {
         status: 200,
         contentType: 'application/json',
-        body: getPhrases()
+        body: getPhrases(req.locales)
     }
 };
 
-var getPhrases = function() {
-    var locales = admin.getLocales();
+var getPhrases = function(locales) {
     var bundle = i18n.getPhrases(locales, ['i18n/common']);
     var phrases = i18n.getPhrases(locales, ['i18n/phrases']);
 


### PR DESCRIPTION
## Summary

XP 8 dropped three functions from `/lib/xp/admin` that the Model Studio admin tool and services still called:

- `admin.getLocales()` — admin tool main.js and i18n service crashed at runtime (`TypeError: admin.getLocales is not a function`).
- `admin.getLauncherPath()` — referenced in `main.js` and emitted into `main.html` for the legacy launcher `<script>`. The launcher is gone from XP 8 ship apps.
- `admin.getBaseUri()` — config service crashed (`TypeError: admin.getBaseUri is not a function`).

Replacements applied:

- Read locale from `req.locales` (matches the pattern in app-applications and app-users).
- Remove the launcher `<script>` tag from `main.html` and drop the `launcherPath` param.
- Derive `adminUrl` in the config service by stripping the app-name suffix from `admin.getToolUrl(app.name, 'main')`. Keeps the field shape that the frontend reads via `lib-admin-ui` `UriHelper.setAdminUri`.

Also bumps the snapshot-only libs for XP 8:

- `lib-graphql` 2.1.0 → 3.0.0-SNAPSHOT
- `lib-mustache` 2.1.1 → 3.0.0-SNAPSHOT

`build.gradle` already calls `xp.enonicRepo('dev')` so the snapshots resolve.

Closes #483

## E2E verification

Booted xp-distro 8.0.0-B4 with the patched jar deployed. After the fix:

- Bundle reaches ACTIVE: `Started application com.enonic.app.modelstudio bundle 119`
- `GET /admin/com.enonic.app.modelstudio/main` → **200**, returns `<title>Model Studio - Enonic XP Admin</title>` with correct asset and config-service URLs.
- `GET …/_/service/com.enonic.app.modelstudio/config` → **200**, includes `adminUrl: "/admin"`, valid `toolUri`/`assetsUri`/services map.
- `GET …/_/service/com.enonic.app.modelstudio/i18n` → **200**, returns the merged phrase bundle.
- `POST …/_/service/com.enonic.app.modelstudio/graphql` with an introspection query → **200**, returns a populated `__schema`.
- All bundled assets (`bundle.js`, styles, icons) serve 200.

Before this PR, the admin tool returned 500 (`admin.getLocales is not a function`) and the config service returned 500 (`admin.getBaseUri is not a function`).

## Out of scope (follow-up)

The visualization service (`/_/service/com.enonic.app.modelstudio/visualization`) still 500s under XP 8:

```
No enum constant com.enonic.xp.resource.DynamicContentSchemaType.XDATA
```

XP 8 collapsed x-data into mixin: `ContentSchemaType` is now `'CONTENT_TYPE' | 'FORM_FRAGMENT' | 'MIXIN'`. `services/visualization/visualization.js` (and the bundled frontend) explicitly model x-data as a separate schema category, so adapting it touches the visualization data model rather than being a one-line rename. Left for a follow-up PR with proper schema-model intent.

## Test plan

- [ ] `./gradlew build --refresh-dependencies` succeeds.
- [ ] On XP 8 (8.0.0-B4 or newer), deploy the jar — bundle reaches ACTIVE.
- [ ] Open `/admin/com.enonic.app.modelstudio/main` while logged in — page loads, title shows "Model Studio".
- [ ] Hit `/admin/com.enonic.app.modelstudio/main/_/service/com.enonic.app.modelstudio/config` — returns valid JSON, no 500.