### PR TITLE
Migrate to lib-asset #485

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     include xplibs.i18n
     include libs.lib.admin.ui
     devResources libs.lib.admin.ui
+    include libs.lib.asset
     include libs.lib.graphql
     include libs.lib.mustache
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,11 @@
 [versions]
 lib-admin-ui = "4.4.0"
+lib-asset = "2.0.0-SNAPSHOT"
 lib-graphql = "3.0.0-SNAPSHOT"
 lib-mustache = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-admin-ui = { module = "com.enonic.lib:lib-admin-ui", version.ref = "lib-admin-ui" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "lib-asset" }
 lib-graphql = { module = "com.enonic.lib:lib-graphql", version.ref = "lib-graphql" }
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "lib-mustache" }

--- a/src/main/resources/admin/tools/main/main.js
+++ b/src/main/resources/admin/tools/main/main.js
@@ -1,12 +1,13 @@
 const mustache = require('/lib/mustache');
 const portal = require('/lib/xp/portal');
 const i18n = require('/lib/xp/i18n');
+const assetLib = require('/lib/enonic/asset');
 
 function handleGet(req) {
     const view = resolve('./main.html');
 
     const params = {
-        assetsUri: portal.assetUrl({path: ''}),
+        assetsUri: assetLib.assetUrl({path: ''}),
         appName: i18n.localize({
             key: 'admin.tool.displayName',
             bundles: ['i18n/phrases'],

--- a/src/main/resources/admin/tools/main/main.yaml
+++ b/src/main/resources/admin/tools/main/main.yaml
@@ -9,3 +9,5 @@ allow:
   - "role:system.admin"
   - "role:system.user.admin"
   - "role:system.user.app"
+apis:
+  - "asset"

--- a/src/main/resources/services/config/config.js
+++ b/src/main/resources/services/config/config.js
@@ -2,6 +2,7 @@
 
 var admin = require('/lib/xp/admin');
 var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 
 function handleGet() {
     var toolUri = admin.getToolUrl(app.name, 'main');
@@ -11,7 +12,7 @@ function handleGet() {
         body: {
             adminUrl: toolUri.substring(0, toolUri.indexOf('/' + app.name)),
             appId: app.name,
-            assetsUri: portal.assetUrl({path: ''}),
+            assetsUri: assetLib.assetUrl({path: ''}),
             toolUri: toolUri,
             services: {
                 visualization: portal.serviceUrl({ service: 'visualization'}),


### PR DESCRIPTION
Closes #485

`portal.assetUrl` is `@deprecated` in lib-portal. This PR moves both call sites in app-modelstudio onto lib-asset.

## Changes

- `build.gradle` + `gradle/libs.versions.toml`: add `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` via the version catalog (`libs.lib.asset`), bundled with `include`.
- `src/main/resources/admin/tools/main/main.yaml`: register the asset API (`apis: ["asset"]`) on the admin tool descriptor so the bundled Universal API is mounted.
- `src/main/resources/admin/tools/main/main.js`: replace `portal.assetUrl({path: ''})` with `assetLib.assetUrl({path: ''})` (import `/lib/enonic/asset`).
- `src/main/resources/services/config/config.js`: same replacement for the config service that feeds `assetsUri` into the SPA.

Admin-tool context only, so lib-asset is the right target (per [lib-asset stable docs](https://developer.enonic.com/docs/lib-asset/stable)).

## Test plan

- [x] `./gradlew build --refresh-dependencies` green
- [x] Deployed inline XP 8.0.0-SNAPSHOT in `claude-dev` (`/tmp/xp-e2e-modelstudio-*`); bundle reached ACTIVE (`Started application com.enonic.app.modelstudio bundle 117`)
- [x] `GET /admin/com.enonic.app.modelstudio/main` returns 200 with rewritten asset URLs (`/admin/.../_/com.enonic.app.modelstudio:asset/<fingerprint>/...`) — exercises `main.js`
- [x] `GET /admin/com.enonic.app.modelstudio/main/_/service/com.enonic.app.modelstudio/config` returns the new `assetsUri` JSON — exercises `config.js`
- [x] Asset URLs return 200 with correct content types: `styles/main.css` (text/css, 12 KB), `admin/common/styles/lib.css` (text/css, 285 KB), `js/bundle.js` (application/javascript, 1.4 MB), `admin/common/js/lib.js` (application/javascript, 982 KB), `icons/favicons/favicon-32x32.png` (image/png), `icons/icon-black.svg` (image/svg+xml), `icons/icon-white.svg` (image/svg+xml — consumed by bundle.js via the config-service `assetsUri`)
- [x] No `ERROR`-level entries in server log

🤖 Generated with [Claude Code](https://claude.com/claude-code)